### PR TITLE
docs(readme): versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,4 +84,5 @@ You can clean common files using `npm run clean`
 You can build node tasks using `npm run build`
 You can package your extension by running `npm run package`. Output will be placed in the `.BuildOutput` subdirectory at root.
 
-
+### Versioning
+You can set version by packaging with `npm run package -- --version <version>`


### PR DESCRIPTION
I take a time to found how to put version, I was receiving a message and didn't know how to provide the version

```
No version argument provided, fallback to default version: 0.0.0
Extension Version: 0.0.999
```