### PR TITLE
fix: force text eol as lf in git and remove deprecated eslint .vscode settings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,7 @@
 ###############################################################################
 # Set default behavior to automatically normalize line endings.
 ###############################################################################
-*           text=auto
+* text=auto eol=lf
 
 # Shell scripts should always use line feed not crlf
 *.sh text eol=lf

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,6 @@
 {
     "eslint.alwaysShowStatus": true,
-    "eslint.autoFixOnSave": true
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": true
+    }
 }


### PR DESCRIPTION
related to #28 